### PR TITLE
Update instructions for Win32 Libraries.

### DIFF
--- a/Libraries.win32/miscellaneous.d/README
+++ b/Libraries.win32/miscellaneous.d/README
@@ -1,8 +1,0 @@
-The following files were downloaded from https://www.microsoft.com/en-us/download/details.aspx?id=48145:
-
-api-ms-win-crt-runtime-l1-1-0.dll
-vcruntime140.dll
-
-Windows XP users, please consider installing vc_redist.x86.exe if you encounter problems with
-api-ms-win-crt-runtime-l1-1-0.dll. The file is also available at
-https://www.microsoft.com/en-us/download/details.aspx?id=48145.

--- a/Libraries.win32/miscellaneous.d/README.md
+++ b/Libraries.win32/miscellaneous.d/README.md
@@ -4,7 +4,7 @@ Microsoft Windows based programs often use shared libraries (called dynamic link
 
 # Dependencies
 
-If BiblioteQ complains about a missing DLL file, then it can probably be resolved by installing the appropriate runtime environment.
+If BiblioteQ complains about a missing DLL file, then it can probably be resolved by installing the appropriate runtime environment.  This is usually done by downloading and installing a file from Microsoft.  In some cases the DLL file mentioned is not part of a runtime, but rather is part of the OS itself, as is often the case with such errors on Windows XP.  See [Unsupported](#unsupported) below.
   
 Here's some BiblioteQ DLL dependencies that are sometimes missing, though there may be others.
 
@@ -19,4 +19,8 @@ If the above doesn't seem to work, try this instead: [Update for Universal C Run
 
 # Unsupported
 
-Windows XP is not supported.  Microsoft stopped supporting Windows XP several years ago.  Qt - the application framework used to build BiblioteQ - stopped supporting Windows XP.  The author of BiblioteQ has likewise abandonned Windows XP development.  If BiblioteQ works on Windows XP, that's great, but it may break at any time in the future, and likely will not be repaired.  Be mindful of that.
+Windows XP is not supported.  Microsoft stopped supporting Windows XP several years ago.  Qt - the application framework used to build BiblioteQ - stopped supporting Windows XP.  The author of BiblioteQ has likewise abandonned Windows XP development.
+
+If BiblioteQ works on Windows XP, that's great, but it may break at any time in the future, and likely will not be repaired.  Be mindful of that.
+
+One way to recognize an OS dependency is when an OS specific DLL file such as `KERNEL23.dll` is mentioned in an error.

--- a/Libraries.win32/miscellaneous.d/README.md
+++ b/Libraries.win32/miscellaneous.d/README.md
@@ -1,0 +1,22 @@
+# Background
+
+Microsoft Windows based programs often use shared libraries (called dynamic link libraries or DLL files) as part of a runtime environment.  There are many versions of these runtimes.  Sometimes a program can't find the version it needs.  Windows will give an error about a "procedure entry point" that "could not be located in the dynamic link library".
+
+# Dependencies
+
+If BiblioteQ complains about a missing DLL file, then it can probably be resolved by installing the appropriate runtime environment.
+  
+Here's some BiblioteQ DLL dependencies that are sometimes missing, though there may be others.
+
+- api-ms-win-crt-runtime-l1-1-0.dll
+- vcruntime140.dll
+
+# Downloads
+
+First try this: [Visual C++ Redistributable for Visual Studio 2015](https://www.microsoft.com/en-us/download/details.aspx?id=48145) and see if that fixes it for you.
+
+If the above doesn't seem to work, try this instead: [Update for Universal C Runtime in Windows](https://support.microsoft.com/en-us/help/2999226/update-for-universal-c-runtime-in-windows) and hopefully that resolves the issue.
+
+# Unsupported
+
+Windows XP is not supported.  Microsoft stopped supporting Windows XP several years ago.  Qt - the application framework that BiblioteQ is built with, stopped supporting Windows XP.  The author of BiblioteQ has likewise abandonned Windows XP development.  If BiblioteQ works on Windows XP, that's great, but it may break at any time in the future, and likely will not be repaired.  Be mindful of that.

--- a/Libraries.win32/miscellaneous.d/README.md
+++ b/Libraries.win32/miscellaneous.d/README.md
@@ -19,4 +19,4 @@ If the above doesn't seem to work, try this instead: [Update for Universal C Run
 
 # Unsupported
 
-Windows XP is not supported.  Microsoft stopped supporting Windows XP several years ago.  Qt - the application framework that BiblioteQ is built with, stopped supporting Windows XP.  The author of BiblioteQ has likewise abandonned Windows XP development.  If BiblioteQ works on Windows XP, that's great, but it may break at any time in the future, and likely will not be repaired.  Be mindful of that.
+Windows XP is not supported.  Microsoft stopped supporting Windows XP several years ago.  Qt - the application framework used to build BiblioteQ - stopped supporting Windows XP.  The author of BiblioteQ has likewise abandonned Windows XP development.  If BiblioteQ works on Windows XP, that's great, but it may break at any time in the future, and likely will not be repaired.  Be mindful of that.

--- a/Libraries.win32/miscellaneous.d/README.md
+++ b/Libraries.win32/miscellaneous.d/README.md
@@ -23,4 +23,4 @@ Windows XP is not supported.  Microsoft stopped supporting Windows XP several ye
 
 If BiblioteQ works on Windows XP, that's great, but it may break at any time in the future, and likely will not be repaired.  Be mindful of that.
 
-One way to recognize an OS dependency is when an OS specific DLL file such as `KERNEL23.dll` is mentioned in an error.
+One way to recognize an OS dependency is when an OS specific DLL file such as `KERNEL32.dll` is mentioned in an error.


### PR DESCRIPTION
Ok, so I followed a recent issue #20 and had some confusion when reading the README file from a user perspective.  Here's my attempt to improve the situation, and the justification for changes.

First, changed to a markdown format, so the page is easier to read on GitHub, with clickable links, but is also highly readable in a console or text editor.

Second, the same URL was mentioned twice, for non WinXP and for WinXP.  Removed the redundancy.

Third, the original instructions advised downloading specific DLLs from the given URL.  The URL had no such DLLs, only the vcredist_x86.exe and vcredist_x64.exe.  I am guessing the DLLs could be extracted from the installers by a savvy user using an archiver program such as 7-Zip.  This approach is problematic for three reasons.  First, users are rarely savvy, so we can't make that assumption.  ;-)  Second, and more importantly, just sticking a DLL somewhere (unspecified, windows system32 folder, program files, etc?) sets up an inconsistent OS environment that becomes harder to manage.  Third, such singleton files exist outside of Windows Update (the native "package manager" [sic]), and so any important security updates won't be made because such file won't ever be detected or offered.  All these issues are resolved by downloading and installing the entire installer.  This creates new issues about Windows Update blindly upgrading runtimes so as to potentially break dependencies in the future, but this is the lesser problem. Such updates won't happen for a long time, and it's better to have a system be updated in the interim rather than existing in a potentially lesser security state.  There's also the problem of installing multiple runtimes, such that cruft gets left behind and upgraded even if unused.  And there's no way to determine if any apps use the runtime until you uninstall the runtime and find an app that complains.  I recently uninstalled about 20 runtimes (many versions and many updates over many years for many apps), and installed a single runtime that was backwards compatible and more recently updated for security.  But even this problem is lesser than trying to ad-hoc drop singleton DLLs all over the place.

Fourth, I broke the file up into sections for readability.  I gave some background information, some general dependency information, the downloads to try (a bit terse, and the previous justification discussion is omitted), and the all-important unsupported section.

Fifth, I'm not sure that it's perfect, but it is something of an improvement.  Can address considerations.

Sixth, I am inexperienced with both Git and GitHub, so I've probably made mistakes in my usage.  If needed, I can redo this from scratch to submit the minimal amount of modifications.