### PR TITLE
Look for biblioteq.conf in application directory on Windows

### DIFF
--- a/Source/biblioteq_a.cc
+++ b/Source/biblioteq_a.cc
@@ -3303,7 +3303,7 @@ void biblioteq::slotSaveUser(void)
 void biblioteq::readGlobalSetup(void)
 {
 #ifdef Q_OS_WIN32
-  QSettings settings("biblioteq.conf", QSettings::IniFormat);
+  QSettings settings(QCoreApplication::applicationDirPath() + QDir::separator() + "biblioteq.conf", QSettings::IniFormat);
 #else
   QSettings settings(BIBLIOTEQ_CONFIGFILE, QSettings::IniFormat);
 #endif


### PR DESCRIPTION
Change the path used when creating the QSettings object for global setup on Windows to look in the directory containing BiblioteQ.exe rather than using whatever is the current directory for the process.

Refs issue #51 