### PR TITLE
Use local app data directory for ini file on Windows

### DIFF
--- a/Source/biblioteq_b.cc
+++ b/Source/biblioteq_b.cc
@@ -9,13 +9,14 @@
 #include <QSqlDriver>
 #include <QSqlField>
 #include <QSqlRecord>
+#include <QStandardPaths>
 
 #include <limits>
 
 QString biblioteq::homePath(void)
 {
 #ifdef Q_OS_WIN32
-  return QDir::currentPath() + QDir::separator() + ".biblioteq";
+  return QStandardPaths::writableLocation(QStandardPaths::StandardLocation::AppConfigLocation);
 #else
   return QDir::homePath() + QDir::separator() + ".biblioteq";
 #endif


### PR DESCRIPTION
Stop putting BiblioteQ.ini in a potentially unwritable location on Windows (i.e. in a subdirectory of where the application is installed). Instead, put the file in a BiblioteQ directory in the user's local app data directory, which should always be writable for the user.