### PR TITLE
Add SPDX header to License

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-/*
+/* SPDX-License-Identifier: BSD-3-Clause
 ** Copyright (c) 2006 - present, Alexis Megas.
 ** All rights reserved.
 **


### PR DESCRIPTION
This allows parsers to understand what license is applying to the project.