### PR TITLE
Add the National Spanish Library z39.50 server

### DIFF
--- a/biblioteq.conf
+++ b/biblioteq.conf
@@ -213,3 +213,16 @@ proxy_port =
 record_syntax = UNIMARC
 timeout = 10
 username =
+
+[Z39.50-9]
+
+format = UTF-8
+hostname = sigb.bne.es
+name = Biblioteca Nacional de España
+password =
+port = 2200
+proxy_host =
+proxy_port =
+record_syntax = MARC21
+timeout = 10
+username =


### PR DESCRIPTION
You can find official documentation here (Spanish): https://www.bne.es/es/servicios/servicios-para-bibliotecarios/suministro-registros/descarga-z3950