### PR TITLE
Wrap homepage search input with SQL wildcards

### DIFF
--- a/Source/biblioteq_b.cc
+++ b/Source/biblioteq_b.cc
@@ -4915,7 +4915,7 @@ void biblioteq::slotSearchBasic(void)
   QString type("");
   QString videoGameFrontCover("'' AS front_cover ");
   QStringList types;
-  auto const text(ui.search->text().trimmed());
+  auto const text("%" + ui.search->text().trimmed() + "%");
   auto query = new QSqlQuery(m_db);
 
   types.append("Book");


### PR DESCRIPTION
Wrap homepage search input with leading and trailing SQL wildcards so searches match substrings.

Change: In `Source/biblioteq_b.cc` (slotSearchBasic) the search input is now constructed as "`%<input>%`" instead of "`<input>`".

Reason: Improve UX by making the main (homepage) quick search perform substring matches automatically without requiring users to type `%.`

Effect: The percent characters are included in the bound parameter passed to the database, so the backend receives the wildcarded value and LIKE queries match substrings. Double '%' is harmless.
Scope: Affects only the homepage/basic search handler.